### PR TITLE
ファイルを分割してテキストファイルにする。

### DIFF
--- a/src/autogpt_plugins/pdf_to_txt/README.md
+++ b/src/autogpt_plugins/pdf_to_txt/README.md
@@ -3,7 +3,7 @@
 ## Features(more coming soon!)
 
 - Convert a PDF file to a text file using the `pdf_to_txt` command
-- \[Future Work\] Convert PDF files to multiple text files
+- Convert PDF files to multiple text files when too long
     - This may be useful when you want to read the converted text file with Auto-GPT, to avoid the limitation of the number of tokens
 
 ## Installation:
@@ -11,3 +11,6 @@ As part of the AutoGPT plugins package, follow the [installation instructions](h
 
 ## AutoGPT Configuration
 Set `ALLOWLISTED_PLUGINS=autogpt-api-tools,example-plugin1,example-plugin2,etc` in your AutoGPT `.env` file.
+
+## Additional tips.
+one chunk is set to 4000 tokens. When you use gpt-3.5 4000 maximum token, you should edit varriable "one_chunk" in pdf_to_txt.py.

--- a/src/autogpt_plugins/pdf_to_txt/__init__.py
+++ b/src/autogpt_plugins/pdf_to_txt/__init__.py
@@ -209,8 +209,8 @@ class AutoGPTPDFToText(AutoGPTPluginTemplate):
             "pdf_to_txt",
             "PDF to Text",
             {
-                "pdf_file_path": "<pdf_file_path>",
-                "txt_file_path": "<txt_file_path>"
+                "pdf_file_name": "<pdf_file_name>",
+                "txt_file_name": "<txt_file_name>"
             },
             pdf2txt
         )

--- a/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
+++ b/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
@@ -51,9 +51,14 @@ def pdf2txt(pdf_file_name: str, txt_file_name: str) -> str:
     chunks_text = split_text_into_chunks(content, "cl100k_base", one_chunk)
 
     # Save each chunk to a separate file
+    # divide filename and extention
+    file_name_without_extension, _ = os.path.splitext(txt_file_name)
+    # if no directory, then make a directory
+    if not os.path.exists(cwd + '/'+file_name_without_extension):
+        os.makedirs(cwd + '/'+file_name_without_extension)
     for i, chunk in enumerate(chunks_text):
         # Construct the filename for each chunk
-        filename = os.path.join(cwd + '/'+txt_file_name, f'{i}{txt_file_name}') #directory and file name to save the text data
+        filename = os.path.join(cwd + '/'+file_name_without_extension, f'{i}{txt_file_name}') #directory and file name to save the text data
         with open(filename, 'w', encoding='utf-8') as file:
             encoding = tiktoken.get_encoding("cl100k_base")
             decoded_text = encoding.decode(chunk)

--- a/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
+++ b/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
@@ -58,7 +58,7 @@ def pdf2txt(pdf_file_name: str, txt_file_name: str) -> str:
         os.makedirs(cwd + '/'+file_name_without_extension)
     for i, chunk in enumerate(chunks_text):
         # Construct the filename for each chunk
-        filename = os.path.join(cwd + '/'+file_name_without_extension, f'{i}{txt_file_name}') #directory and file name to save the text data
+        filename = os.path.join(cwd + '/'+file_name_without_extension, f'{file_name_without_extension}_chunk_{i}.txt') #directory and file name to save the text data
         with open(filename, 'w', encoding='utf-8') as file:
             encoding = tiktoken.get_encoding("cl100k_base")
             decoded_text = encoding.decode(chunk)

--- a/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
+++ b/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
@@ -1,9 +1,33 @@
 from __future__ import annotations
-from . import AutoGPTPDFToText
+from .import AutoGPTPDFToText
 import fitz
 import os
+import tiktoken
 
 plugin = AutoGPTPDFToText()
+one_chunk = 4000 #amount of token in one chunk
+
+
+def split_text_into_chunks(text: str, encoding_name: str, chunk_size: int) -> list:
+    encoding = tiktoken.get_encoding(encoding_name)
+    tokens = encoding.encode(text)
+    chunks = []
+    current_chunk = []
+    current_size = 0
+
+    for token in tokens:
+        current_chunk.append(token)
+        current_size += 1  # Increment size by 1 for each token
+        if current_size >= chunk_size:
+            chunks.append(current_chunk)
+            current_chunk = []
+            current_size = 0
+    
+    # Add the last chunk if it's not empty
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    return chunks
 
 def pdf2txt(pdf_file_path: str, txt_file_path: str) -> str:
     """Convert a PDF file to a text file.
@@ -19,11 +43,20 @@ def pdf2txt(pdf_file_path: str, txt_file_path: str) -> str:
     cwd = os.path.normpath(cwd)
 
     doc = fitz.open(cwd + '/' + pdf_file_path) # open a document
-    out = open(cwd + '/' + txt_file_path, "wb") # create a text output
     for page in doc: # iterate the document pages
         text = page.get_text().encode("utf8") # get plain text (is in UTF-8)
-        out.write(text) # write text of page
-        out.write(bytes((12,))) # write page delimiter (form feed 0x0C)
-    out.close()
+        content.append(text)
+
+    chunks = split_text_into_chunks(content, "cl100k_base", one_chunk)
+
+    # Save each chunk to a separate file
+    for i, chunk in enumerate(chunks):
+        # Construct the filename for each chunk
+        filename = os.path.join(cwd + '/', f'{i}{txt_file_path}') #directory and file name to save the text data
+        with open(filename, 'w', encoding='utf-8') as file:
+            encoding = tiktoken.get_encoding("cl100k_base")
+            decoded_text = encoding.decode(chunk)
+            file.write(decoded_text)
+
 
     return "Success! The PDF file was converted to a text file."

--- a/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
+++ b/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
@@ -29,11 +29,11 @@ def split_text_into_chunks(text: str, encoding_name: str, chunk_size: int) -> li
 
     return chunks
 
-def pdf2txt(pdf_file_path: str, txt_file_path: str) -> str:
+def pdf2txt(pdf_file_name: str, txt_file_name: str) -> str:
     """Convert a PDF file to a text file.
     Args:
-        pdf_filen_path (str): The PDF file path.
-        txt_filen_path (str): The TXT file path.
+        pdf_filen_name (str): The PDF file path.
+        txt_filen_name (str): The TXT file path.
     Returns:
         str: The tweet that was posted.
     """
@@ -42,17 +42,18 @@ def pdf2txt(pdf_file_path: str, txt_file_path: str) -> str:
     cwd = os.path.join(dirname, '../../../../../../autogpt/auto_gpt_workspace')
     cwd = os.path.normpath(cwd)
 
-    doc = fitz.open(cwd + '/' + pdf_file_path) # open a document
+    doc = fitz.open(cwd + '/' + pdf_file_name) # open a document
+    content = "" # Initialize the content variable
     for page in doc: # iterate the document pages
         text = page.get_text().encode("utf8") # get plain text (is in UTF-8)
         content += text.decode("utf8")
 
-    chunks = split_text_into_chunks(content, "cl100k_base", one_chunk)
+    chunks_text = split_text_into_chunks(content, "cl100k_base", one_chunk)
 
     # Save each chunk to a separate file
-    for i, chunk in enumerate(chunks):
+    for i, chunk in enumerate(chunks_text):
         # Construct the filename for each chunk
-        filename = os.path.join(cwd + '/', f'{i}{txt_file_path}') #directory and file name to save the text data
+        filename = os.path.join(cwd + '/'+txt_file_name, f'{i}{txt_file_name}') #directory and file name to save the text data
         with open(filename, 'w', encoding='utf-8') as file:
             encoding = tiktoken.get_encoding("cl100k_base")
             decoded_text = encoding.decode(chunk)

--- a/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
+++ b/src/autogpt_plugins/pdf_to_txt/pdf_to_txt.py
@@ -45,7 +45,7 @@ def pdf2txt(pdf_file_path: str, txt_file_path: str) -> str:
     doc = fitz.open(cwd + '/' + pdf_file_path) # open a document
     for page in doc: # iterate the document pages
         text = page.get_text().encode("utf8") # get plain text (is in UTF-8)
-        content.append(text)
+        content += text.decode("utf8")
 
     chunks = split_text_into_chunks(content, "cl100k_base", one_chunk)
 

--- a/src/autogpt_plugins/pdf_to_txt/test_pdf_to_txt_plugin.py
+++ b/src/autogpt_plugins/pdf_to_txt/test_pdf_to_txt_plugin.py
@@ -1,4 +1,4 @@
-from .import (
+from .pdf_to_txt import (
     pdf2txt,
 )
 

--- a/src/autogpt_plugins/pdf_to_txt/test_pdf_to_txt_plugin.py
+++ b/src/autogpt_plugins/pdf_to_txt/test_pdf_to_txt_plugin.py
@@ -1,4 +1,4 @@
-from .pdf_to_txt import (
+from .import (
     pdf2txt,
 )
 


### PR DESCRIPTION
## 目的
PDFをテキストに変換してautogptで読み込む際に、8000token以上のファイルはmaxmize tokenでエラーを起こしていました。4000tokenごとに分割してテキストファイルを保存するようにしました。

## 破壊的変更をもたらしますか
[X] Yes
[ ] No

## Pull Request の種類
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:

## 検証方法
### コードの検証
ai_settings.yaml
```
ai_goals:
- I want you to read paper1.pdf in workspace
- output it in the text
- summerize the contents
ai_name: pdf reader
ai_role: an agent to read pdf and summarize
api_budget: 0.0
```

## 確認事項
あらかじめPDFをworkspaceに配置してファイル名をプロンプトに記載する。
自動でworkspace内にフォルダーができて、テキストファイルをそこに保存します。
